### PR TITLE
Add Thai word segmentation using PyThaiNLP

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ We implement custom fallback pretoknizers for the following writing systems:
   using [jieba](https://github.com/fxsjy/jieba)
 - [x] [Japanese writing system](https://en.wikipedia.org/wiki/Japanese_writing_system) -
   using [fugashi](https://github.com/polm/fugashi)
+- [x] [Thai script](https://en.wikipedia.org/wiki/Thai_script) -
+  using [PyThaiNLP](https://github.com/PyThaiNLP/pythainlp)
 - [ ] [Balinese script](https://en.wikipedia.org/wiki/Balinese_script)
 - [ ] [Burmese alphabet](https://en.wikipedia.org/wiki/Burmese_alphabet)
 - [ ] [Chữ Hán](https://en.wikipedia.org/wiki/Ch%E1%BB%AF_H%C3%A1n)
@@ -84,7 +86,6 @@ We implement custom fallback pretoknizers for the following writing systems:
 - [ ] [Scriptio continua](https://en.wikipedia.org/wiki/Scriptio_continua)
 - [ ] [S'gaw Karen alphabet](https://en.wikipedia.org/wiki/S%27gaw_Karen_alphabet)
 - [ ] [Tai Tham script](https://en.wikipedia.org/wiki/Tai_Tham_script)
-- [ ] [Thai script](https://en.wikipedia.org/wiki/Thai_script)
 - [ ] [Tibetan script](https://en.wikipedia.org/wiki/Tibetan_script)
 - [ ] [Vietnamese alphabet](https://en.wikipedia.org/wiki/Vietnamese_alphabet)
 - [ ] [Western Pwo alphabet](https://en.wikipedia.org/wiki/Western_Pwo_alphabet)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "utf8-tokenizer",
     "fugashi[unidic-lite]", # For Japanese word segmentation
     "jieba", # For Chinese word segmentation
+    "pythainlp", # For Thai word segmentation
     "signwriting", # For SignWriting segmentation
 ]
 

--- a/tests/test_thai.py
+++ b/tests/test_thai.py
@@ -1,0 +1,70 @@
+import pytest
+
+from words_segmentation.thai import has_thai, segment_thai
+
+
+def test_has_thai_simple():
+    """Test has_thai with simple Thai text."""
+    assert has_thai("สวัสดี")
+    assert has_thai("ภาษาไทย")
+    assert has_thai("ผมรักเมืองไทย")
+
+
+def test_has_thai_mixed_content():
+    """Test has_thai with mixed Thai and other characters."""
+    assert has_thai("hello สวัสดี")
+    assert has_thai("mixed ไทย")
+    assert has_thai("123 ภาษาไทย abc")
+    assert has_thai("English ไทย ผสม")
+
+
+def test_has_thai_no_thai():
+    """Test has_thai with non-Thai text."""
+    assert not has_thai("hello")
+    assert not has_thai("English text")
+    assert not has_thai("123456")
+    assert not has_thai("!@#$%^&*()")
+    assert not has_thai("こんにちは")  # Japanese
+    assert not has_thai("你好")  # Chinese
+    assert not has_thai("ລາວ")  # Lao
+
+
+def test_has_thai_empty_string():
+    """Test has_thai with empty string."""
+    assert not has_thai("")
+
+
+def test_has_thai_whitespace_only():
+    """Test has_thai with whitespace only."""
+    assert not has_thai(" ")
+    assert not has_thai("\n\t")
+    assert not has_thai("   ")
+
+
+def test_segment_thai_simple():
+    """Test segment_thai with a single Thai word."""
+    result = segment_thai("สวัสดี")
+    assert result == ["สวัสดี"]
+
+
+def test_segment_thai_empty():
+    """Test segment_thai with empty string."""
+    result = segment_thai("")
+    assert result == []
+
+
+def test_segment_thai_sentence():
+    """Test segment_thai with a Thai sentence without spaces."""
+    result = segment_thai("ผมรักเมืองไทย")
+    assert result == ["ผม", "รัก", "เมือง", "ไทย"]
+
+
+def test_segment_thai_compound_words():
+    """Test segment_thai with compound words."""
+    result = segment_thai("การประมวลผลภาษาธรรมชาติ")
+    assert "".join(result) == "การประมวลผลภาษาธรรมชาติ"
+    assert len(result) > 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_thai.py
+++ b/tests/test_thai.py
@@ -1,5 +1,6 @@
 import pytest
 
+from words_segmentation.languages import segment_text
 from words_segmentation.thai import has_thai, segment_thai
 
 
@@ -64,6 +65,12 @@ def test_segment_thai_compound_words():
     result = segment_thai("การประมวลผลภาษาธรรมชาติ")
     assert "".join(result) == "การประมวลผลภาษาธรรมชาติ"
     assert len(result) > 1
+
+
+def test_segment_text_dispatches_thai():
+    """Test that Thai text is routed to segment_thai via LANGUAGE_SPECS."""
+    result = list(segment_text("ผมรักเมืองไทย"))
+    assert result == [["ผม", "รัก", "เมือง", "ไทย"]]
 
 
 if __name__ == "__main__":

--- a/words_segmentation/languages.py
+++ b/words_segmentation/languages.py
@@ -18,6 +18,7 @@ from utf8_tokenizer.control import CONTROl_TOKENS_PATTERN
 from words_segmentation.chinese import segment_chinese
 from words_segmentation.japanese import segment_japanese
 from words_segmentation.signwriting import segment_signwriting
+from words_segmentation.thai import segment_thai
 
 # Three classes of tokens inside the Default branch:
 # 1) Control tokens (always atomic)
@@ -53,6 +54,10 @@ LANGUAGE_SPECS: dict[str, LanguageSpec] = {
     "Japanese": {
         "scripts": ("Han", "Hiragana", "Katakana"),
         "callback": segment_japanese,
+    },
+    "Thai": {
+        "scripts": ("Thai",),
+        "callback": segment_thai,
     },
     "Default": {
         "scripts": tuple(),

--- a/words_segmentation/thai.py
+++ b/words_segmentation/thai.py
@@ -1,0 +1,72 @@
+"""
+Thai text pretokenization utilities.
+
+This module provides functions for detecting and segmenting Thai text using the pythainlp
+library for word segmentation.
+"""
+
+from functools import cache
+
+import regex
+
+
+def has_thai(text: str) -> bool:
+    """
+    Check if the given text contains Thai characters.
+
+    Args:
+        text: The input text to check for Thai characters
+
+    Returns:
+        True if Thai characters are found, False otherwise
+    """
+    # Match any character in the Thai Unicode script
+    return bool(regex.search(r'[\p{Thai}]', text))
+
+
+@cache
+def get_thai_segmenter():
+    """
+    Get a cached instance of the PyThaiNLP Thai word tokenizer.
+
+    PyThaiNLP is a popular Thai text processing library that uses a combination of
+    dictionary-based matching and statistical models to segment Thai text into words.
+    The tokenizer is cached to avoid repeated initialization overhead.
+
+    Returns:
+        pythainlp word tokenization function for text segmentation
+
+    Raises:
+        ImportError: If the pythainlp library is not installed
+    """
+    try:
+        from pythainlp.tokenize import word_tokenize
+    except ImportError:
+        print("Error: pythainlp library not found. Please install it with: pip install pythainlp")
+        raise
+
+    return word_tokenize
+
+
+def segment_thai(text: str) -> list[str]:
+    """
+    Segment Thai text into words.
+
+    Thai is written without spaces between words, so this uses PyThaiNLP's word
+    tokenizer to break Thai text into individual words. This preprocessing step
+    helps the tokenizer better understand Thai text structure.
+
+    Args:
+        text: The Thai text to segment
+
+    Returns:
+        List of Thai words
+
+    Example:
+        >>> segment_thai("สวัสดีโลก")
+        ["สวัสดี", "โลก"]
+    """
+    word_tokenize = get_thai_segmenter()
+    segments = word_tokenize(text)
+    # Filter out empty segments the tokenizer may produce
+    return [segment for segment in segments if segment]


### PR DESCRIPTION
## Description

Redo of #6 (by @wannaphong, credited as co-author) — adds Thai language segmentation using [PyThaiNLP](https://github.com/PyThaiNLP/pythainlp). The original PR went unresponsive, so this picks it up with all review comments addressed and CI fixed:

- Fixed lint failure: `thai` import in `languages.py` was out of alphabetical order (ruff isort).
- Fixed module docstring that described "Chinese text pretokenization" (copy-paste from `chinese.py`).
- `has_thai` now uses the Unicode script property `\p{Thai}` (consistent with `has_chinese`'s `\p{Han}`), and its comment no longer claims to match Han ideographs.
- Fixed `segment_thai` docstring example to show the actual `list[str]` return value.
- `segment_thai` now actually filters empty segments, matching its comment.
- Added `tests/test_thai.py` following the `test_chinese.py` pattern (9 tests).
- Moved the Thai entry in the README up next to the other implemented scripts.

## Tests

- `ruff check .` passes.
- Full suite: 93 passed, 1 skipped.
- End-to-end: `segment_text('hello ผมรักเมืองไทย world สวัสดีโลก')` → `['hello ', 'ผม', 'รัก', 'เมือง', 'ไทย', ' ', 'world ', 'สวัสดี', 'โลก']`

Closes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Follows the existing Chinese/Japanese pretokenizer pattern with no auth or data-path changes; main impact is a new optional dependency and segmentation behavior for Thai script.
> 
> **Overview**
> Adds **Thai script** as a custom pretokenizer alongside Chinese and Japanese, so unspaced Thai text is split into words before the main tokenizer runs.
> 
> A new `words_segmentation/thai.py` module provides `\p{Thai}` detection (`has_thai`), a cached PyThaiNLP `word_tokenize` wrapper, and `segment_thai` that returns a filtered `list[str]`. **`LANGUAGE_SPECS`** registers the Thai script with `segment_thai`, so `segment_text` routes Thai spans automatically (and respects `LANGUAGES_NO_SPLIT` like other languages).
> 
> **`pythainlp`** is added as a runtime dependency; the README marks Thai as implemented. **`tests/test_thai.py`** covers detection, segmentation, and dispatch through `segment_text`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aa59173fa6960983c2ae58661ebcfdefa256dde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Thai language detection and word segmentation.
  * Thai text is now automatically recognized and split into words, including mixed-language content.
  * Added support for Thai segmentation through PyThaiNLP.

* **Documentation**
  * Updated the supported writing systems list to include Thai.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->